### PR TITLE
Change name of Azure Storage private endpoints.

### DIFF
--- a/infra/core/networking/private-networking.bicep
+++ b/infra/core/networking/private-networking.bicep
@@ -54,7 +54,7 @@ module storagePrivateEndpoint 'private-endpoint.bicep' = [for (svc, i) in storag
   params: {
     dnsZoneName: 'privatelink.${svc}.${environment().suffixes.storage}'
     location: location
-    privateEndpointName: 'pe-${svc}'
+    privateEndpointName: 'pe-${storage.name}-${svc}'
     privateLinkServiceId: storage.id
     subnetId: vnet::privateEndpointSubnet.id
     virtualNetworkName: vnet.name


### PR DESCRIPTION
This pull request modifies the private endpoint name in `private-networking.bicep` to ensure uniqueness for each storage account.

* <a href="diffhunk://#diff-d4f72bf46476a38afd636a8852da6974b72b744bdc4f2db86e5474553539720aL57-R57">`infra/core/networking/private-networking.bicep`</a>: Modified the private endpoint name to include the storage account name for uniqueness.